### PR TITLE
Replace System.Drawing Font usage with SkiaSharp SKFont

### DIFF
--- a/Scryber.Common/Options/FontOptions.cs
+++ b/Scryber.Common/Options/FontOptions.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace Scryber.Options
+﻿namespace Scryber.Options
 {
     public class FontOptions
     {
@@ -30,17 +28,12 @@ namespace Scryber.Options
         }
     }
 
-
-
     public class FontRegistrationOption
     {
         public string Family { get; set; }
 
-        public System.Drawing.FontStyle Style { get; set; }
+        public string Style { get; set; }
 
         public string File { get; set; }
     }
-
-
-
 }

--- a/Scryber.Common/Scryber.Common.csproj
+++ b/Scryber.Common/Scryber.Common.csproj
@@ -20,7 +20,6 @@
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="5.0.0" />
-    <PackageReference Include="System.Drawing.Common" Version="5.0.0" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Options\" />

--- a/Scryber.Components/Components/Component.cs
+++ b/Scryber.Components/Components/Component.cs
@@ -25,7 +25,6 @@
 using System;
 using System.Collections.Generic;
 using System.Text;
-using System.Drawing;
 using Scryber.Native;
 using Scryber.Styles;
 using Scryber.Drawing;

--- a/Scryber.Components/Components/ContainerComponent.cs
+++ b/Scryber.Components/Components/ContainerComponent.cs
@@ -19,7 +19,6 @@
 using System;
 using System.Collections.Generic;
 using System.Text;
-using System.Drawing;
 using Scryber.Styles;
 using Scryber.Drawing;
 using Scryber.Native;

--- a/Scryber.Components/Components/PageBase.cs
+++ b/Scryber.Components/Components/PageBase.cs
@@ -18,9 +18,7 @@
 
 using System;
 using System.Collections.Generic;
-using System.Text;
 using Scryber.Native;
-using System.Drawing;
 using Scryber.Styles;
 using Scryber.Resources;
 using Scryber.Drawing;

--- a/Scryber.Components/Components/TextLiteral.cs
+++ b/Scryber.Components/Components/TextLiteral.cs
@@ -19,7 +19,6 @@
 using System;
 using System.Collections.Generic;
 using System.Text;
-using System.Drawing;
 using Scryber.Styles;
 using Scryber.Native;
 using Scryber.Text;

--- a/Scryber.Components/Components/VisualComponent.cs
+++ b/Scryber.Components/Components/VisualComponent.cs
@@ -20,7 +20,6 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 using Scryber.Native;
-using System.Drawing;
 using Scryber.Styles;
 using Scryber.Resources;
 using Scryber.Drawing;

--- a/Scryber.Components/Data/Base64Data.cs
+++ b/Scryber.Components/Data/Base64Data.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.ComponentModel;
-using System.Drawing;
 
 namespace Scryber.Data
 {

--- a/Scryber.Components/PDFRenderContext.cs
+++ b/Scryber.Components/PDFRenderContext.cs
@@ -19,7 +19,6 @@
 using System;
 using System.Collections.Generic;
 using System.Text;
-using System.Drawing;
 using Scryber.Drawing;
 using Scryber.Styles;
 

--- a/Scryber.Components/_Interface.cs
+++ b/Scryber.Components/_Interface.cs
@@ -20,7 +20,6 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 using Scryber.Native;
-using System.Drawing;
 using Scryber.Drawing;
 using Scryber.Components;
 using Scryber.Layout;

--- a/Scryber.Core.UnitTest/Binding/ExpressionBinding_Test.cs
+++ b/Scryber.Core.UnitTest/Binding/ExpressionBinding_Test.cs
@@ -16,6 +16,8 @@ using Scryber.Expressive.Operators;
 using System.Threading.Tasks;
 using System.Xml;
 using Scryber.Html;
+using System.Threading;
+using System.Globalization;
 
 namespace Scryber.Core.UnitTests.Binding
 {
@@ -271,6 +273,8 @@ namespace Scryber.Core.UnitTests.Binding
         [TestMethod]
         public void AllExpressions_Test()
         {
+            Thread.CurrentThread.CurrentCulture = CultureInfo.InvariantCulture;
+
             var model = new
             {
                 number = 20.7,
@@ -866,6 +870,8 @@ namespace Scryber.Core.UnitTests.Binding
         [TestCategory("Binding")]
         public void BindCalcAllFunctions()
         {
+            Thread.CurrentThread.CurrentCulture = CultureInfo.InvariantCulture;
+
             var model = new
             {
                 number = 20.7,

--- a/Scryber.Core.UnitTest/Configuration/SetConfig_Test.cs
+++ b/Scryber.Core.UnitTest/Configuration/SetConfig_Test.cs
@@ -151,7 +151,6 @@ namespace Scryber.Core.UnitTests.Configuration
             Assert.AreEqual(3, font.Register.Length, "There are not 3 registered fonts");
 
             var family = "Segoe UI";
-            var style = System.Drawing.FontStyle.Regular;
             var fileStem = "Mocks/Fonts/";
             var fileExt = ".ttf";
             var fileName = "segoeui";
@@ -159,23 +158,21 @@ namespace Scryber.Core.UnitTests.Configuration
             //Segoe UI Regular
             var option = font.Register[0]; 
             Assert.AreEqual(family, option.Family);
-            Assert.AreEqual(style, option.Style);
+            Assert.IsNull(option.Style);
             Assert.AreEqual(fileStem + fileName + fileExt, option.File);
 
             // Segoe UI Bold
             option = font.Register[1]; 
-            style = System.Drawing.FontStyle.Bold;
 
             Assert.AreEqual(family, option.Family);
-            Assert.AreEqual(style, option.Style);
+            Assert.AreEqual("Bold", option.Style);
             Assert.AreEqual(fileStem + fileName + "b" + fileExt, option.File);
 
             // Segoe UI Bold
             option = font.Register[2];
-            style = System.Drawing.FontStyle.Italic;
 
             Assert.AreEqual(family, option.Family);
-            Assert.AreEqual(style, option.Style);
+            Assert.AreEqual("Italic", option.Style);
             Assert.AreEqual(fileStem + fileName + "i" + fileExt, option.File);
 
             ConfigClassCleanup();

--- a/Scryber.Core.UnitTest/Drawing/PDFFont_Test.cs
+++ b/Scryber.Core.UnitTest/Drawing/PDFFont_Test.cs
@@ -304,14 +304,14 @@ namespace Scryber.Core.UnitTests.Drawing
             PDFUnit size = 12;
             PDFFont target = new PDFFont(family, size);
 
-            
-            System.Drawing.FontStyle actual;
-            actual = target.GetDrawingStyle();
-            Assert.AreEqual(System.Drawing.FontStyle.Regular, actual);
 
-            target.FontStyle = FontStyle.Italic | FontStyle.Bold;
+            SkiaSharp.SKFontStyle actual;
             actual = target.GetDrawingStyle();
-            Assert.AreEqual(System.Drawing.FontStyle.Bold | System.Drawing.FontStyle.Italic, actual);
+            Assert.AreEqual(SkiaSharp.SKFontStyle.Normal, actual);
+
+            target.FontStyle = FontStyle.BoldItalic;
+            actual = target.GetDrawingStyle();
+            Assert.AreEqual(SkiaSharp.SKFontStyle.BoldItalic, actual);
 
         }
 
@@ -323,8 +323,8 @@ namespace Scryber.Core.UnitTests.Drawing
         public void GetDrawingStyle_Test1()
         {
             FontStyle fontStyle = FontStyle.Bold;
-            System.Drawing.FontStyle expected = System.Drawing.FontStyle.Bold;
-            System.Drawing.FontStyle actual;
+            SkiaSharp.SKFontStyle expected = SkiaSharp.SKFontStyle.Bold;
+            SkiaSharp.SKFontStyle actual;
             actual = PDFFont.GetDrawingStyle(fontStyle);
             Assert.AreEqual(expected, actual);
         }

--- a/Scryber.Drawing/Drawing/PDFFontFactory.cs
+++ b/Scryber.Drawing/Drawing/PDFFontFactory.cs
@@ -23,7 +23,6 @@ using System.Collections.Generic;
 using System.Configuration;
 using System.Linq;
 using System.Text;
-//using System.Drawing;
 using System.Drawing.Text;
 using Scryber.Resources;
 using Scryber.Configuration;
@@ -54,7 +53,7 @@ namespace Scryber.Drawing
         private abstract class FontReference
         {
             internal string FamilyName { get; private set; }
-            internal System.Drawing.FontStyle Style { get; private set; }
+            internal SkiaSharp.SKFontStyle Style { get; private set; }
             internal string FilePath { get; private set; }
             internal byte[] FileData { get; private set; }
             internal int FileHeadOffset { get; private set; }
@@ -67,7 +66,7 @@ namespace Scryber.Drawing
 
             internal object LoadLock { get; private set; }
             
-            internal FontReference(string name, System.Drawing.FontStyle style, string path, int fileHeadOffset)
+            internal FontReference(string name, SkiaSharp.SKFontStyle style, string path, int fileHeadOffset)
             {
                 //this.SystemFamily = family;
                 this.FamilyName = name;
@@ -77,7 +76,7 @@ namespace Scryber.Drawing
                 this.LoadLock = new object();
             }
 
-            internal FontReference(string name, System.Drawing.FontStyle style, byte[] data, int fileHeadOffset)
+            internal FontReference(string name, SkiaSharp.SKFontStyle style, byte[] data, int fileHeadOffset)
             {
                 //this.SystemFamily = family;
                 this.FamilyName = name;
@@ -100,12 +99,12 @@ namespace Scryber.Drawing
         {
             internal LinkedFontReference Next { get; set; }
 
-            internal LinkedFontReference(string familyname, System.Drawing.FontStyle style, string path, int fileHeadOffset)
+            internal LinkedFontReference(string familyname, SkiaSharp.SKFontStyle style, string path, int fileHeadOffset)
                 : base(familyname, style, path, fileHeadOffset)
             {
             }
 
-            internal LinkedFontReference(string familyname, System.Drawing.FontStyle style, byte[] data, int fileHeadOffset)
+            internal LinkedFontReference(string familyname, SkiaSharp.SKFontStyle style, byte[] data, int fileHeadOffset)
                 : base(familyname, style, data, fileHeadOffset)
             {
             }
@@ -118,7 +117,7 @@ namespace Scryber.Drawing
                     this.Next.Append(reference);
             }
 
-            internal LinkedFontReference GetStyle(System.Drawing.FontStyle style)
+            internal LinkedFontReference GetStyle(SkiaSharp.SKFontStyle style)
             {
                 if (style == this.Style)
                     return this;
@@ -166,7 +165,7 @@ namespace Scryber.Drawing
                 get { return _first; }
             }
 
-            internal FontReference this[System.Drawing.FontStyle style]
+            internal FontReference this[SkiaSharp.SKFontStyle style]
             {
                 get
                 {
@@ -182,7 +181,7 @@ namespace Scryber.Drawing
                 this.FamilyName = name;
             }
 
-            internal FontReference Add(System.Drawing.FontStyle style, string filepath, int fileHeadOffset)
+            internal FontReference Add(SkiaSharp.SKFontStyle style, string filepath, int fileHeadOffset)
             {
 
                 LinkedFontReference fontref = new LinkedFontReference(this.FamilyName, style, filepath, fileHeadOffset);
@@ -194,7 +193,7 @@ namespace Scryber.Drawing
                 return fontref;
             }
 
-            internal FontReference Add(System.Drawing.FontStyle style, byte[] data, int fileHeadOffset)
+            internal FontReference Add(SkiaSharp.SKFontStyle style, byte[] data, int fileHeadOffset)
             {
                 LinkedFontReference fontref = new LinkedFontReference(this.FamilyName, style, data, fileHeadOffset);
                 if (null == _first)
@@ -205,7 +204,7 @@ namespace Scryber.Drawing
                 return fontref;
             }
 
-            internal bool TryGetFont(System.Drawing.FontStyle style, out FontReference font)
+            internal bool TryGetFont(SkiaSharp.SKFontStyle style, out FontReference font)
             {
                 var found = _first;
                 while(null != found)
@@ -258,7 +257,7 @@ namespace Scryber.Drawing
                 }
             }
 
-            internal FontReference this[string family, System.Drawing.FontStyle style]
+            internal FontReference this[string family, SkiaSharp.SKFontStyle style]
             {
                 get
                 {
@@ -292,7 +291,7 @@ namespace Scryber.Drawing
                 }
             }
 
-            internal virtual FontReference AddFontFile(string family, System.Drawing.FontStyle style, string path, int fileHeadOffset)
+            internal virtual FontReference AddFontFile(string family, SkiaSharp.SKFontStyle style, string path, int fileHeadOffset)
             {
                 FamilyReference fam;
                 if (_families.TryGetValue(family, out fam) == false)
@@ -303,7 +302,7 @@ namespace Scryber.Drawing
                 return fam.Add(style, path, fileHeadOffset);
             }
 
-            internal FontReference AddFontResource(string family, System.Drawing.FontStyle style, byte[] data, int fileHeadOffset)
+            internal FontReference AddFontResource(string family, SkiaSharp.SKFontStyle style, byte[] data, int fileHeadOffset)
             {
                 FamilyReference fam;
                 if (_families.TryGetValue(family, out fam) == false)
@@ -324,7 +323,7 @@ namespace Scryber.Drawing
                 return _families.TryGetValue(name, out reference);
             }
 
-            internal bool TryGetFont(string name, System.Drawing.FontStyle style, out FontReference reference)
+            internal bool TryGetFont(string name, SkiaSharp.SKFontStyle style, out FontReference reference)
             {
                 reference = null;
                 FamilyReference family;
@@ -420,7 +419,7 @@ namespace Scryber.Drawing
         #endregion
 
         /*
-        #region public static Font GetSystemFont(string family, System.Drawing.FontStyle style, float size)
+        #region public static Font GetSystemFont(string family, SkiaSharp.SKFontStyle style, float size)
 
         /// <summary>
         /// Gets a System.Drawing.Font based upon the family, style and size.
@@ -429,7 +428,7 @@ namespace Scryber.Drawing
         /// <param name="style">The style of the font</param>
         /// <param name="size">The size of the font</param>
         /// <returns>A new System.Drawing.Font</returns>
-        public static Font GetSystemFont(string family, System.Drawing.FontStyle style, float size)
+        public static Font GetSystemFont(string family, SkiaSharp.SKFontStyle style, float size)
         {
             //Make sure we are initialized and OK
             AssertInitialized();
@@ -448,8 +447,8 @@ namespace Scryber.Drawing
                 fref = _genericfamilies[family, style];
 
 #if FALLBACKTOREGULAR
-            if (null == fref && style != System.Drawing.FontStyle.Regular)
-                return GetSystemFont(family, System.Drawing.FontStyle.Regular, size);
+            if (null == fref && style != SkiaSharp.SKFontStyle.Normal)
+                return GetSystemFont(family, SkiaSharp.SKFontStyle.Normal, size);
 #endif
             if (null == fref)
             {
@@ -492,7 +491,7 @@ namespace Scryber.Drawing
             //Make sure we are initialized and OK
             AssertInitialized();
 
-            System.Drawing.FontStyle fs = font.GetDrawingStyle();
+            SkiaSharp.SKFontStyle fs = font.GetDrawingStyle();
             PDFFontSelector selector = font.Selector;
             while (null != selector)
             {
@@ -510,14 +509,14 @@ namespace Scryber.Drawing
 
         #endregion
 
-        #region public static bool IsFontDefined(string family, System.Drawing.FontStyle style)
+        #region public static bool IsFontDefined(string family, SkiaSharp.SKFontStyle style)
         /// <summary>
         /// Returns true if the available fonts contain one with the specified family and style
         /// </summary>
         /// <param name="family">The name of the font family (case insensitive)</param>
         /// <param name="style">GThe required stlye of the font</param>
         /// <returns>True if available, or false</returns>
-        public static bool IsFontDefined(string family, System.Drawing.FontStyle style)
+        public static bool IsFontDefined(string family, SkiaSharp.SKFontStyle style)
         {
             //Make sure we are initialized and OK
             AssertInitialized();
@@ -539,8 +538,8 @@ namespace Scryber.Drawing
                 fref = _genericfamilies[family, style];
 
 #if FALLBACKTOREGULAR
-            if (null == fref && style != System.Drawing.FontStyle.Regular && !PDFFont.IsStandardFontFamily(family))
-                return IsFontDefined(family, System.Drawing.FontStyle.Regular);
+            if (null == fref && style != SkiaSharp.SKFontStyle.Normal && !PDFFont.IsStandardFontFamily(family))
+                return IsFontDefined(family, SkiaSharp.SKFontStyle.Normal);
 #endif
 
             if (null == fref)
@@ -600,17 +599,21 @@ namespace Scryber.Drawing
         public static PDFFontDefinition GetFontDefinition(string fullname)
         {
             int pos = fullname.IndexOf(",");
-            System.Drawing.FontStyle fontstyle = System.Drawing.FontStyle.Regular;
+            SkiaSharp.SKFontStyle fontstyle = SkiaSharp.SKFontStyle.Normal;
             string family;
             if (pos > 0)
             {
                 family = fullname.Substring(0, pos).Trim();
                 string style = fullname.Substring(pos);
                 if (style.IndexOf("bold", StringComparison.OrdinalIgnoreCase) > -1)
-                    fontstyle = fontstyle | System.Drawing.FontStyle.Bold;
+                    fontstyle = SkiaSharp.SKFontStyle.Bold;
 
                 if (style.IndexOf("italic", StringComparison.OrdinalIgnoreCase) > -1)
-                    fontstyle = fontstyle | System.Drawing.FontStyle.Italic;
+                    fontstyle = SkiaSharp.SKFontStyle.Italic;
+
+                if (style.IndexOf("bold", StringComparison.OrdinalIgnoreCase) > -1 && 
+                    style.IndexOf("italic", StringComparison.OrdinalIgnoreCase) > -1)
+                    fontstyle = SkiaSharp.SKFontStyle.BoldItalic;
             }
             else
                 family = fullname.Trim();
@@ -621,7 +624,7 @@ namespace Scryber.Drawing
 
         #endregion
 
-        #region public static PDFFontDefinition GetFontDefinition(string family, System.Drawing.FontStyle style, bool throwNotFound = true)
+        #region public static PDFFontDefinition GetFontDefinition(string family, SkiaSharp.SKFontStyle style, bool throwNotFound = true)
 
         /// <summary>
         /// Gets the PDFFontDefinition for the specified famil and style
@@ -631,7 +634,7 @@ namespace Scryber.Drawing
         /// <param name="throwNotFound">If true (default) then if the font cannot be found an exception will be raised.
         /// If not, then null will be returned.</param>
         /// <returns></returns>
-        public static PDFFontDefinition GetFontDefinition(string family, System.Drawing.FontStyle style, bool throwNotFound = true)
+        public static PDFFontDefinition GetFontDefinition(string family, SkiaSharp.SKFontStyle style, bool throwNotFound = true)
         {
             //Make sure we are initialized and OK
             AssertInitialized();
@@ -657,8 +660,8 @@ namespace Scryber.Drawing
             if (null == fref)
             {
 
-                if (usesubstitute && style != System.Drawing.FontStyle.Regular && !PDFFont.IsStandardFontFamily(family))
-                    return GetFontDefinition(family, System.Drawing.FontStyle.Regular, throwNotFound);
+                if (usesubstitute && style != SkiaSharp.SKFontStyle.Normal && !PDFFont.IsStandardFontFamily(family))
+                    return GetFontDefinition(family, SkiaSharp.SKFontStyle.Normal, throwNotFound);
 
                 //We dont have the explicit font so if we should substitue then 
                 //try to find the family and return that otherwise use courier.
@@ -982,7 +985,8 @@ namespace Scryber.Drawing
                 foreach (var map in known)
                 {
                     string family = map.Family;
-                    System.Drawing.FontStyle style = map.Style;
+
+                    SkiaSharp.SKFontStyle style = SKFontStyleMapping(map.Style);
 
                    
                     if (!string.IsNullOrEmpty(map.File))
@@ -1049,6 +1053,18 @@ namespace Scryber.Drawing
 
         #endregion
 
+        private static SkiaSharp.SKFontStyle SKFontStyleMapping(string styleName)
+        {
+            if (styleName == "Bold")
+                return SkiaSharp.SKFontStyle.Bold;
+            else if (styleName == "Italic")
+                return SkiaSharp.SKFontStyle.Italic;
+            else if (styleName == "BoldItalic")
+                return SkiaSharp.SKFontStyle.BoldItalic;
+
+            return SkiaSharp.SKFontStyle.Normal;
+        }
+
         #region private static FamilyReferenceBag LoadStaticFamilies()
 
         const int HelveticaSpaceWidthFU = 569;
@@ -1070,26 +1086,26 @@ namespace Scryber.Drawing
                 TTFFile file;
                 //Courier
                 bin = GetFontBinary(assm, "Scryber.Text._FontResources.Courier.CourierNew.ttf", out ttrRef);
-                fRef = bag.AddFontResource("Courier", System.Drawing.FontStyle.Regular, bin, ttrRef.HeadOffset);
+                fRef = bag.AddFontResource("Courier", SkiaSharp.SKFontStyle.Normal, bin, ttrRef.HeadOffset);
                 file = new TTFFile(bin, ttrRef.HeadOffset);
                 fRef.Definition = PDFFontDefinition.InitStdType1WinAnsi("Fcour", "Courier", "Courier", "Courier New", false, false, CourierSpaceWidthFU, file); ;
 
 
 
                 bin = GetFontBinary(assm, "Scryber.Text._FontResources.Courier.CourierNewBold.ttf", out ttrRef);
-                fRef = bag.AddFontResource("Courier", System.Drawing.FontStyle.Bold, bin, ttrRef.HeadOffset);
+                fRef = bag.AddFontResource("Courier", SkiaSharp.SKFontStyle.Bold, bin, ttrRef.HeadOffset);
                 file = new TTFFile(bin, ttrRef.HeadOffset);
                 fRef.Definition = PDFFontDefinition.InitStdType1WinAnsi("FcourBo", "Courier-Bold", "Courier", "Courier New", true, false, CourierSpaceWidthFU, file);
 
 
                 bin = GetFontBinary(assm, "Scryber.Text._FontResources.Courier.CourierNewBoldItalic.ttf", out ttrRef);
-                fRef = bag.AddFontResource("Courier", System.Drawing.FontStyle.Bold | System.Drawing.FontStyle.Italic, bin, ttrRef.HeadOffset);
+                fRef = bag.AddFontResource("Courier", SkiaSharp.SKFontStyle.BoldItalic, bin, ttrRef.HeadOffset);
                 file = new TTFFile(bin, ttrRef.HeadOffset);
                 fRef.Definition = PDFFontDefinition.InitStdType1WinAnsi("FcourBoOb", "Courier-BoldOblique", "Courier", "Courier New", true, true, CourierSpaceWidthFU, file);
 
 
                 bin = GetFontBinary(assm, "Scryber.Text._FontResources.Courier.CourierNewItalic.ttf", out ttrRef);
-                fRef = bag.AddFontResource("Courier", System.Drawing.FontStyle.Italic, bin, ttrRef.HeadOffset);
+                fRef = bag.AddFontResource("Courier", SkiaSharp.SKFontStyle.Italic, bin, ttrRef.HeadOffset);
                 file = new TTFFile(bin, ttrRef.HeadOffset);
                 fRef.Definition = PDFFontDefinition.InitStdType1WinAnsi("FcourOb", "Courier-Oblique", "Courier", "Courier New", false, true, CourierSpaceWidthFU, file);
 
@@ -1097,22 +1113,22 @@ namespace Scryber.Drawing
                 //Helvetica
 
                 bin = GetFontBinary(assm, "Scryber.Text._FontResources.Helvetica.Helvetica.ttf", out ttrRef);
-                fRef = bag.AddFontResource("Helvetica", System.Drawing.FontStyle.Regular, bin, ttrRef.HeadOffset);
+                fRef = bag.AddFontResource("Helvetica", SkiaSharp.SKFontStyle.Normal, bin, ttrRef.HeadOffset);
                 file = new TTFFile(bin, ttrRef.HeadOffset);
                 fRef.Definition = PDFFontDefinition.InitStdType1WinAnsi("Fhel", "Helvetica", "Helvetica", false, false, HelveticaSpaceWidthFU, file);
 
                 bin = GetFontBinary(assm, "Scryber.Text._FontResources.Helvetica.HelveticaBold.ttf", out ttrRef);
-                fRef = bag.AddFontResource("Helvetica", System.Drawing.FontStyle.Bold, bin, ttrRef.HeadOffset);
+                fRef = bag.AddFontResource("Helvetica", SkiaSharp.SKFontStyle.Bold, bin, ttrRef.HeadOffset);
                 file = new TTFFile(bin, ttrRef.HeadOffset);
                 fRef.Definition = PDFFontDefinition.InitStdType1WinAnsi("FhelBl", "Helvetica-Bold", "Helvetica", true, false, HelveticaSpaceWidthFU, file);
 
                 bin = GetFontBinary(assm, "Scryber.Text._FontResources.Helvetica.HelveticaBoldOblique.ttf", out ttrRef);
-                fRef = bag.AddFontResource("Helvetica", System.Drawing.FontStyle.Bold | System.Drawing.FontStyle.Italic, bin, ttrRef.HeadOffset);
+                fRef = bag.AddFontResource("Helvetica", SkiaSharp.SKFontStyle.BoldItalic, bin, ttrRef.HeadOffset);
                 file = new TTFFile(bin, ttrRef.HeadOffset);
                 fRef.Definition = PDFFontDefinition.InitStdType1WinAnsi("FhelObBl", "Helvetica-BoldOblique", "Helvetica", true, true, HelveticaSpaceWidthFU, file);
 
                 bin = GetFontBinary(assm, "Scryber.Text._FontResources.Helvetica.HelveticaOblique.ttf", out ttrRef);
-                fRef = bag.AddFontResource("Helvetica", System.Drawing.FontStyle.Italic, bin, ttrRef.HeadOffset);
+                fRef = bag.AddFontResource("Helvetica", SkiaSharp.SKFontStyle.Italic, bin, ttrRef.HeadOffset);
                 file = new TTFFile(bin, ttrRef.HeadOffset);
                 fRef.Definition = PDFFontDefinition.InitStdType1WinAnsi("FhelOb", "Helvetica-Oblique", "Helvetica", false, true, HelveticaSpaceWidthFU, file);
 
@@ -1120,7 +1136,7 @@ namespace Scryber.Drawing
                 //Symbol
 
                 bin = GetFontBinary(assm, "Scryber.Text._FontResources.Symbol.Symbol.ttf", out ttrRef);
-                fRef = bag.AddFontResource("Symbol", System.Drawing.FontStyle.Regular, bin, ttrRef.HeadOffset);
+                fRef = bag.AddFontResource("Symbol", SkiaSharp.SKFontStyle.Normal, bin, ttrRef.HeadOffset);
                 file = new TTFFile(bin, ttrRef.HeadOffset);
                 fRef.Definition = PDFFontDefinition.InitStdSymbolType1WinAnsi("Fsym", "Symbol", SymbolSpaceWidthFU, file);
 
@@ -1128,22 +1144,22 @@ namespace Scryber.Drawing
                 //Times
 
                 bin = GetFontBinary(assm, "Scryber.Text._FontResources.Times.timesNewRoman.ttf", out ttrRef);
-                fRef = bag.AddFontResource("Times", System.Drawing.FontStyle.Regular, bin, ttrRef.HeadOffset);
+                fRef = bag.AddFontResource("Times", SkiaSharp.SKFontStyle.Normal, bin, ttrRef.HeadOffset);
                 file = new TTFFile(bin, ttrRef.HeadOffset);
                 fRef.Definition = PDFFontDefinition.InitStdType1WinAnsi("Ftimes", "Times-Roman", "Times", false, false, TimesSpaceWidthFU, file);
 
                 bin = GetFontBinary(assm, "Scryber.Text._FontResources.Times.timesNewRomanBold.ttf", out ttrRef);
-                fRef = bag.AddFontResource("Times", System.Drawing.FontStyle.Bold, bin, ttrRef.HeadOffset);
+                fRef = bag.AddFontResource("Times", SkiaSharp.SKFontStyle.Bold, bin, ttrRef.HeadOffset);
                 file = new TTFFile(bin, ttrRef.HeadOffset);
                 fRef.Definition = PDFFontDefinition.InitStdType1WinAnsi("FtimesBo", "Times-Bold", "Times", true, false, TimesSpaceWidthFU, file);
 
                 bin = GetFontBinary(assm, "Scryber.Text._FontResources.Times.timesNewRomanBoldItalic.ttf", out ttrRef);
-                fRef = bag.AddFontResource("Times", System.Drawing.FontStyle.Bold | System.Drawing.FontStyle.Italic, bin, ttrRef.HeadOffset);
+                fRef = bag.AddFontResource("Times", SkiaSharp.SKFontStyle.BoldItalic, bin, ttrRef.HeadOffset);
                 file = new TTFFile(bin, ttrRef.HeadOffset);
                 fRef.Definition = PDFFontDefinition.InitStdType1WinAnsi("FtimesBoIt", "Times-BoldItalic", "Times", true, true, TimesSpaceWidthFU, file);
 
                 bin = GetFontBinary(assm, "Scryber.Text._FontResources.Times.timesNewRomanItalic.ttf", out ttrRef);
-                fRef = bag.AddFontResource("Times", System.Drawing.FontStyle.Italic, bin, ttrRef.HeadOffset);
+                fRef = bag.AddFontResource("Times", SkiaSharp.SKFontStyle.Italic, bin, ttrRef.HeadOffset);
                 file = new TTFFile(bin, ttrRef.HeadOffset);
                 fRef.Definition = PDFFontDefinition.InitStdType1WinAnsi("FtimesIt", "Times-Italic", "Times", false, true, TimesSpaceWidthFU, file);
 
@@ -1152,7 +1168,7 @@ namespace Scryber.Drawing
                 //Zapf
 
                 bin = GetFontBinary(assm, "Scryber.Text._FontResources.Zaph.ZapfDingbats.ttf", out ttrRef);
-                fRef = bag.AddFontResource("Zapf Dingbats", System.Drawing.FontStyle.Regular, bin, ttrRef.HeadOffset);
+                fRef = bag.AddFontResource("Zapf Dingbats", SkiaSharp.SKFontStyle.Normal, bin, ttrRef.HeadOffset);
                 file = new TTFFile(bin, ttrRef.HeadOffset);
                 fRef.Definition = PDFFontDefinition.InitStdSymbolType1WinAnsi("Fzapf", "ZapfDingbats", ZaphSpaceWidthFU, file);
                 fRef.Definition.Family = "Zapf Dingbats";
@@ -1263,28 +1279,28 @@ namespace Scryber.Drawing
 
         #endregion
 
-        #region private static System.Drawing.FontStyle GetFontStyle(Scryber.OpenType.SubTables.FontSelection fs)
+        #region private static SkiaSharp.SKFontStyle GetFontStyle(Scryber.OpenType.SubTables.FontSelection fs)
 
         /// <summary>
         /// Converts a OpenType.FontSelection to a Drawing.FontStyle
         /// </summary>
         /// <param name="fs"></param>
         /// <returns></returns>
-        private static System.Drawing.FontStyle GetFontStyle(Scryber.OpenType.SubTables.FontSelection fs, Scryber.OpenType.SubTables.WeightClass wc)
+        private static SkiaSharp.SKFontStyle GetFontStyle(Scryber.OpenType.SubTables.FontSelection fs, Scryber.OpenType.SubTables.WeightClass wc)
         {
-            System.Drawing.FontStyle style = System.Drawing.FontStyle.Regular;
+            SkiaSharp.SKFontStyle style = SkiaSharp.SKFontStyle.Normal;
 
             if ((fs & Scryber.OpenType.SubTables.FontSelection.Italic) > 0)
-                style |= System.Drawing.FontStyle.Italic;
-            if ((fs & Scryber.OpenType.SubTables.FontSelection.Underscore) > 0)
-                style |= System.Drawing.FontStyle.Underline;
-            if ((fs & Scryber.OpenType.SubTables.FontSelection.Strikeout) > 0)
-                style |= System.Drawing.FontStyle.Strikeout;
+                style = SkiaSharp.SKFontStyle.Italic;
+            //if ((fs & Scryber.OpenType.SubTables.FontSelection.Underscore) > 0)
+            //    style = SkiaSharp.SKFontStyle.Underline;
+            //if ((fs & Scryber.OpenType.SubTables.FontSelection.Strikeout) > 0)
+            //    style = SkiaSharp.SKFontStyle.Strikeout;
             if ((fs & Scryber.OpenType.SubTables.FontSelection.Bold) > 0)
-                style |= System.Drawing.FontStyle.Bold;
+                style = SkiaSharp.SKFontStyle.Bold;
 
             if (wc == OpenType.SubTables.WeightClass.Bold)
-                style |= System.Drawing.FontStyle.Bold;
+                style = SkiaSharp.SKFontStyle.Bold;
 
             return style;
         }
@@ -1295,7 +1311,7 @@ namespace Scryber.Drawing
         // PDFFontSource ensure methods
         //
 
-        public static bool TryEnsureFont(IPDFComponent mapper, PDFContextBase context, PDFFontSource source, string familyName, System.Drawing.FontStyle style, out PDFFontDefinition definition)
+        public static bool TryEnsureFont(IPDFComponent mapper, PDFContextBase context, PDFFontSource source, string familyName, SkiaSharp.SKFontStyle style, out PDFFontDefinition definition)
         {
             AssertInitialized();
 
@@ -1369,7 +1385,7 @@ namespace Scryber.Drawing
             return found;
         }
 
-        private static bool TryLoadRemoteDefinition(PDFContextBase context, string url, string family, System.Drawing.FontStyle style, out PDFFontDefinition definition)
+        private static bool TryLoadRemoteDefinition(PDFContextBase context, string url, string family, SkiaSharp.SKFontStyle style, out PDFFontDefinition definition)
         {
             bool tried = true;
             definition = null;

--- a/Scryber.Drawing/Drawing/PDFFont_c.cs
+++ b/Scryber.Drawing/Drawing/PDFFont_c.cs
@@ -16,11 +16,7 @@
  * 
  */
 
-using System;
 using System.Collections.Generic;
-using System.Text;
-using System.Drawing;
-using Scryber.Configuration;
 using System.ComponentModel;
 using Scryber.Resources;
 
@@ -388,24 +384,28 @@ namespace Scryber.Drawing
             //int line = sys.FontFamily.GetLineSpacing(style);
         }
 
-        public System.Drawing.FontStyle GetDrawingStyle()
+        public SkiaSharp.SKFontStyle GetDrawingStyle()
         {
             return GetDrawingStyle(this.FontStyle);
         }
 
         /// <summary>
-        /// Converts the PDFX.FontStyle to a System.Drawing.FontStyle
+        /// Converts the PDFX.FontStyle to a SkiaSharp.SKFontStyle
         /// </summary>
         /// <param name="fontStyle">The PDFX.FontStyle</param>
-        /// <returns>A comparable System.Drawing.FontStyle</returns>
-        public static System.Drawing.FontStyle GetDrawingStyle(FontStyle fontStyle)
+        /// <returns>A comparable SkiaSharp.SKFontStyle</returns>
+        public static SkiaSharp.SKFontStyle GetDrawingStyle(FontStyle fontStyle)
         {
-            System.Drawing.FontStyle fs = System.Drawing.FontStyle.Regular;
+            SkiaSharp.SKFontStyle fs = SkiaSharp.SKFontStyle.Normal;
+
             if ((fontStyle & FontStyle.Bold) > 0)
-                fs |= System.Drawing.FontStyle.Bold;
+                fs = SkiaSharp.SKFontStyle.Bold;
 
             if ((fontStyle & FontStyle.Italic) > 0)
-                fs |= System.Drawing.FontStyle.Italic;
+                fs = SkiaSharp.SKFontStyle.Italic;
+
+            if ((fontStyle & FontStyle.Bold) > 0 && (fontStyle & FontStyle.Italic) > 0)
+                fs = SkiaSharp.SKFontStyle.BoldItalic;
 
             return fs;
         }

--- a/Scryber.Drawing/Drawing/PDFGraphics_Text.cs
+++ b/Scryber.Drawing/Drawing/PDFGraphics_Text.cs
@@ -21,7 +21,6 @@ using System.Collections.Generic;
 using System.Text;
 using Scryber.Text;
 using Scryber.Native;
-using System.Drawing;
 using Scryber.Resources;
 using System.Runtime.CompilerServices;
 

--- a/Scryber.Drawing/Drawing/PDFThickness_c.cs
+++ b/Scryber.Drawing/Drawing/PDFThickness_c.cs
@@ -19,7 +19,6 @@
 using System;
 using System.Collections.Generic;
 using System.Text;
-using System.Drawing;
 using System.ComponentModel;
 using System.Linq.Expressions;
 

--- a/Scryber.Drawing/Drawing/_Enumerations.cs
+++ b/Scryber.Drawing/Drawing/_Enumerations.cs
@@ -121,6 +121,7 @@ namespace Scryber.Drawing
         Regular = 0,
         Bold = 1,
         Italic = 2,
+        BoldItalic = 3,
         Superscript = 4,
         Subscript = 8
     }

--- a/Scryber.Drawing/PDFFonts.cs
+++ b/Scryber.Drawing/PDFFonts.cs
@@ -18,8 +18,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Text;
-using System.Drawing;
 using Scryber.Resources;
 
 namespace Scryber
@@ -285,10 +283,10 @@ namespace Scryber
             return GetStandardFontDefinition(font.FamilyName, font.GetDrawingStyle());
         }
 
-        public static PDFFontDefinition GetStandardFontDefinition(string name, FontStyle style)
+        public static PDFFontDefinition GetStandardFontDefinition(string name, SkiaSharp.SKFontStyle style)
         {
-            bool italic = (style & FontStyle.Italic) > 0;
-            bool bold = (style & FontStyle.Bold) > 0;
+            bool italic = style == SkiaSharp.SKFontStyle.Italic;
+            bool bold = style == SkiaSharp.SKFontStyle.Bold;
             name = TranslateGenericName(name);
 
             foreach (PDFFontDefinition defn in _stds)

--- a/Scryber.Drawing/Resources/PDFFontDefinition.cs
+++ b/Scryber.Drawing/Resources/PDFFontDefinition.cs
@@ -408,27 +408,29 @@ namespace Scryber.Resources
 
 
 
-        #region OBSELETE public System.Drawing.Font GetSystemFont(float pointsize)
+        //#region OBSELETE public System.Drawing.Font GetSystemFont(float pointsize)
 
-        /// <summary>
-        /// Gets the System.Drawing.Font that represents this PDFFontDefintion
-        /// </summary>
-        /// <param name="pointsize"></param>
-        /// <returns></returns>
-        [Obsolete("Dont use system fonts anymore", true)]
-        public System.Drawing.Font GetSystemFont(float pointsize)
-        {
-            System.Drawing.FontStyle fs = System.Drawing.FontStyle.Regular;
-            if (this.Bold)
-                fs |= System.Drawing.FontStyle.Bold;
-            if (this.Italic)
-                fs |= System.Drawing.FontStyle.Italic;
+        ///// <summary>
+        ///// Gets the System.Drawing.Font that represents this PDFFontDefintion
+        ///// </summary>
+        ///// <param name="pointsize"></param>
+        ///// <returns></returns>
+        //[Obsolete("Dont use system fonts anymore", true)]
+        //public System.Drawing.Font GetSystemFont(float pointsize)
+        //{
+        //    SkiaSharp.SKFontStyle fs = SkiaSharp.SKFontStyle.Normal;
+        //    if (this.Bold)
+        //        fs = SkiaSharp.SKFontStyle.Bold;
+        //    if (this.Italic)
+        //        fs = SkiaSharp.SKFontStyle.Italic;
+        //    if (this.Bold && this.Italic)
+        //        fs = SkiaSharp.SKFontStyle.BoldItalic;
 
-            System.Drawing.Font f = new System.Drawing.Font(this.WindowsName, pointsize, fs);
-            return f;
-        }
+        //    System.Drawing.Font f = new System.Drawing.Font(this.WindowsName, pointsize, fs);
+        //    return f;
+        //}
 
-        #endregion
+        //#endregion
 
         // object overrides
 
@@ -980,7 +982,7 @@ namespace Scryber.Resources
         /// <param name="style"></param>
         /// <returns></returns>
         [Obsolete("Use the generic bag instead", true)]
-        public static PDFFontDefinition LoadStandardFont(string family, System.Drawing.FontStyle style)
+        public static PDFFontDefinition LoadStandardFont(string family, SkiaSharp.SKFontStyle style)
         {
             PDFFontDefinition defn;
             if (PDFFont.IsStandardFontFamily(family))
@@ -995,7 +997,7 @@ namespace Scryber.Resources
 
         #endregion
 
-        #region internal static PDFFontDefinition LoadOpenTypeFontFile(string path, string familyname, System.Drawing.FontStyle style)
+        #region internal static PDFFontDefinition LoadOpenTypeFontFile(string path, string familyname, SkiaSharp.SKFontStyle style)
 
         /// <summary>
         /// Loads an OpenType font file from the specified path based on the name and style
@@ -1004,7 +1006,7 @@ namespace Scryber.Resources
         /// <param name="familyname">The font family name in the file</param>
         /// <param name="style">The style (bold, italic etc) for the font</param>
         /// <returns>The new PDFFontDefinition</returns>
-        internal static PDFFontDefinition LoadOpenTypeFontFile(string path, string familyname, System.Drawing.FontStyle style, int headOffset)
+        internal static PDFFontDefinition LoadOpenTypeFontFile(string path, string familyname, SkiaSharp.SKFontStyle style, int headOffset)
         {
             if (string.IsNullOrEmpty(path))
                 throw new ArgumentNullException("path");
@@ -1026,7 +1028,7 @@ namespace Scryber.Resources
 
         #endregion
 
-        #region internal static PDFFontDefinition LoadOpenTypeFontFile(byte[] data, string familyname, System.Drawing.FontStyle style)
+        #region internal static PDFFontDefinition LoadOpenTypeFontFile(byte[] data, string familyname, SkiaSharp.SKFontStyle style)
 
         /// <summary>
         /// Loads an OpenType font from the provided binary data based on the family name and font style
@@ -1035,7 +1037,7 @@ namespace Scryber.Resources
         /// <param name="familyname">The family name (Helvetica, Arial, etc) for the font</param>
         /// <param name="style">The style (Bold, Italic, etc) for the font</param>
         /// <returns>A new PDFFontDefinition for the font</returns>
-        internal static PDFFontDefinition LoadOpenTypeFontFile(byte[] data, string familyname, System.Drawing.FontStyle style, int headOffset)
+        internal static PDFFontDefinition LoadOpenTypeFontFile(byte[] data, string familyname, SkiaSharp.SKFontStyle style, int headOffset)
         {
             if (null == data || data.Length == 0)
                 throw new ArgumentNullException("data");
@@ -1056,7 +1058,7 @@ namespace Scryber.Resources
 
         #endregion
 
-        #region internal static PDFFontDefinition LoadOpenTypeFontFile(Scryber.OpenType.TTFFile ttf, string familyname, System.Drawing.FontStyle style)
+        #region internal static PDFFontDefinition LoadOpenTypeFontFile(Scryber.OpenType.TTFFile ttf, string familyname, SkiaSharp.SKFontStyle style)
 
         /// <summary>
         /// Loads and returns a new PDFFontDefinition for the provided OpenType font with the name and style
@@ -1065,7 +1067,7 @@ namespace Scryber.Resources
         /// <param name="familyname">The font family name</param>
         /// <param name="style">The font style</param>
         /// <returns>A new PDFFontDefinition</returns>
-        internal static PDFFontDefinition LoadOpenTypeFontFile(Scryber.OpenType.TTFFile ttf, string familyname, System.Drawing.FontStyle style)
+        internal static PDFFontDefinition LoadOpenTypeFontFile(Scryber.OpenType.TTFFile ttf, string familyname, SkiaSharp.SKFontStyle style)
         {
             if (null == ttf)
                 throw new ArgumentNullException("ttf");
@@ -1082,8 +1084,8 @@ namespace Scryber.Resources
                 defn.TTFFile = ttf;
                 
                 defn.BaseType = ttf.Tables.Names.GetInvariantName(NameIDFullFamily).Replace(" ", "");
-                defn.Bold = (style & System.Drawing.FontStyle.Bold) > 0;
-                defn.Italic = (style & System.Drawing.FontStyle.Italic) > 0;
+                defn.Bold = style == SkiaSharp.SKFontStyle.Bold;
+                defn.Italic = style == SkiaSharp.SKFontStyle.Italic;
                 defn.WindowsName = defn.BaseType;
                 defn.IsEmbedable = IsEmbeddable(ttf);
                 defn.Descriptor = GetFontDescriptor(defn.BaseType, defn.IsEmbedable, ttf);

--- a/Scryber.Drawing/Resources/PDFFontDescriptor.cs
+++ b/Scryber.Drawing/Resources/PDFFontDescriptor.cs
@@ -17,9 +17,6 @@
  */
 
 using System;
-using System.Collections.Generic;
-using System.Text;
-using System.Drawing;
 using Scryber.Native;
 using Scryber.Drawing;
 

--- a/Scryber.Drawing/Resources/PDFImageTilingPattern.cs
+++ b/Scryber.Drawing/Resources/PDFImageTilingPattern.cs
@@ -17,10 +17,6 @@
  */
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Drawing;
 using Scryber.Native;
 using Scryber.Drawing;
 

--- a/Scryber.Drawing/Scryber.Drawing.csproj
+++ b/Scryber.Drawing/Scryber.Drawing.csproj
@@ -13,13 +13,14 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DebugType></DebugType>
-    <DefineConstants>TRACE;RELEASE;NET;NET5_0;NETCOREAPP;MAC_OS</DefineConstants>
+    <DefineConstants>TRACE;RELEASE;NET;NET5_0;NETCOREAPP</DefineConstants>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Scryber.Common\Scryber.Common.csproj" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="SkiaSharp" Version="2.80.3" />
     <PackageReference Include="System.Text.Encoding" Version="4.3.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="Scryber.Core.OpenType" Version="5.0.3" />
@@ -28,7 +29,6 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="5.0.0" />
-    <PackageReference Include="System.Drawing.Common" Version="5.0.0" />
   </ItemGroup>
   <ItemGroup>
     <Compile Remove="Errors1.Designer.cs" />

--- a/Scryber.Styles/Styles/StyleDefn.cs
+++ b/Scryber.Styles/Styles/StyleDefn.cs
@@ -17,9 +17,7 @@
  */
 
 using System;
-using System.Collections.Generic;
 using System.Text;
-using System.Drawing;
 using System.ComponentModel;
 using Scryber.Styles.Selectors;
 

--- a/Scryber.Styles/Styles/StyleFontFace.cs
+++ b/Scryber.Styles/Styles/StyleFontFace.cs
@@ -1,8 +1,6 @@
-﻿using System;
-using System.Drawing;
-using System.Net.Sockets;
-using Scryber.Drawing;
+﻿using Scryber.Drawing;
 using Scryber.Resources;
+using SkiaSharp;
 
 namespace Scryber.Styles
 {
@@ -183,16 +181,16 @@ namespace Scryber.Styles
             return "@font-face";
         }
 
-        
-
-        
         private bool TryGetFont(IPDFDocument doc, PDFContextBase context, out PDFFontDefinition definition)
         {
-            System.Drawing.FontStyle style = System.Drawing.FontStyle.Regular;
+            var style = SKFontStyle.Normal;
+
             if (this.FontBold)
-                style |= System.Drawing.FontStyle.Bold;
+                style = SKFontStyle.Bold;
             if (this.FontItalic)
-                style |= System.Drawing.FontStyle.Italic;
+                style = SKFontStyle.Italic;
+            if (this.FontItalic && this.FontBold)
+                style = SKFontStyle.BoldItalic;
 
             string name = this.FontFamily.FamilyName;
 
@@ -200,7 +198,5 @@ namespace Scryber.Styles
             
             return null != definition;
         }
-        
-
     }
 }


### PR DESCRIPTION
related to #69 

At the risk of rejecting everything, I still tried replacing the use of System.Drawing with SkiaSharp.
https://github.com/mono/SkiaSharp

For cross-platform support, the use of SkiaSharp from Microsoft is recommended.
https://docs.microsoft.com/en-us/dotnet/core/compatibility/core-libraries/6.0/system-drawing-common-windows-only

This pull request replaces the usage of **System.Drawing Font** with SkiaSharp **SKFont**.
It solves issues of loading fonts in linux.

- All Tests are running.
- My tests under windows and linux are successfully. 
([SkiaSharp.NativeAssets.Linux](https://www.nuget.org/packages/SkiaSharp.NativeAssets.Linux))

But I don't know all other special test cases.

Thank you for feedback.