### PR TITLE
#107 SVG Paths with containing dots does not work in Culture de-DE

### DIFF
--- a/Scryber.Core.sln.DotSettings.user
+++ b/Scryber.Core.sln.DotSettings.user
@@ -1,5 +1,7 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
 	<s:Boolean x:Key="/Default/AddReferences/RecentPaths/=_002FUsers_002Frichard_002FProjects_002FScryber_002FScryber_002ECore_002FScryber_002EImaging_002FImageSharp_002FNet5_002E0_002FSixLabors_002EImageSharp_002Edll/@EntryIndexedValue">True</s:Boolean>
 	<s:String x:Key="/Default/Environment/UnitTesting/UnitTestSessionStore/Sessions/=7f7196bc_002D2ef0_002D442b_002D9493_002De13924ae652a/@EntryIndexedValue">&lt;SessionState ContinuousTestingMode="0" IsActive="True" Name="All tests from &amp;lt;Scryber.UnitTests&amp;gt;" xmlns="urn:schemas-jetbrains-com:jetbrains-ut-session"&gt;
-  &lt;Project Location="/Users/richard/Projects/Scryber/Scryber.Core/Scryber.UnitTest" Presentation="&amp;lt;Scryber.UnitTests&amp;gt;" /&gt;
+  &lt;TestAncestor&gt;
+    &lt;TestId&gt;MSTest::6930F3FB-89E2-4E30-A29F-2BFBF5FD0DEF::net6.0::Scryber.Core.UnitTests.Html.SVGParsing_Tests&lt;/TestId&gt;
+  &lt;/TestAncestor&gt;
 &lt;/SessionState&gt;</s:String></wpf:ResourceDictionary>

--- a/Scryber.Drawing/Drawing/Unit.cs
+++ b/Scryber.Drawing/Drawing/Unit.cs
@@ -23,6 +23,7 @@ using Scryber.PDF;
 using Scryber.PDF.Native;
 using Scryber.PDF.Resources;
 using System.CodeDom;
+using System.Globalization;
 
 namespace Scryber.Drawing
 {
@@ -876,12 +877,19 @@ namespace Scryber.Drawing
                 throw new ArgumentException(String.Format(Errors.CouldNotParseValue_3, value, "PDFUnit", "nnn[.nnn](mm|in|pt)"), "value");
 
             offset = end;
+
+            var valueForParsing = value.Substring(start, end - start);
             
-            double d;
-            if (double.TryParse(value.Substring(start, end - start), out d))
-                return d;
-            else
-                throw new ArgumentException(String.Format(Errors.CouldNotParseValue_3, value, "PDFUnit", "nnn[.nnn](mm|in|pt)"), "value");
+            if (double.TryParse(valueForParsing, out var d1))
+            {
+                return d1;
+            }
+            if (double.TryParse(valueForParsing, NumberStyles.Any, CultureInfo.InvariantCulture, out var d2))
+            {
+                return d2;
+            }
+            
+            throw new ArgumentException(String.Format(Errors.CouldNotParseValue_3, value, "PDFUnit", "nnn[.nnn](mm|in|pt)"), "value");
 
         }
 

--- a/Scryber.UnitTest/Html/SVGParsing_Tests.cs
+++ b/Scryber.UnitTest/Html/SVGParsing_Tests.cs
@@ -1,18 +1,9 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Scryber.Components;
 using Scryber.Html.Components;
 using Scryber.Styles;
 using Scryber.Drawing;
-using Scryber.Styles.Parsing;
-
-using Scryber.PDF.Layout;
-using Scryber.PDF;
-using System.Xml.Schema;
 using Scryber.Svg.Components;
 using System.IO;
 
@@ -223,11 +214,42 @@ namespace Scryber.Core.UnitTests.Html
             Assert.AreEqual(1, div.Contents.Count);
             svg = div.Contents[0] as SVGCanvas;
             Assert.IsNotNull(svg);
+        }
+        
+        /// <summary>
+        /// Test case for Issue #107
+        /// </summary>
+        [TestMethod]
+        public void SVGToComponentWithInvariantUnits()
+        {
+            var svgString = @"
+            <svg width=""1000"" height=""400"" xmlns=""http://www.w3.org/2000/svg"" xmlns:xlink=""http://www.w3.org/1999/xlink"" version=""1.1"" baseProfile=""full"" style=""position:absolute;left:0;top:0;user-select:none"">
+              <rect width=""1000"" height=""400"" x=""0"" y=""0"" id=""0"" fill=""none"" fill-opacity=""1""></rect>
+              <g>
+                <path d=""M503.1463 120.0619L503.7363 105.0735L745 105.0735"" fill=""none"" stroke=""#5470c6""></path>
+                <path d=""M504.3059 279.884L505.1132 294.8623L649 294.8623"" fill=""none"" stroke=""#91cc75""></path>
+                <path d=""M488.3618 120.8511L417.7603 131.2324L291 131.2324"" fill=""none"" stroke=""#fac858""></path>
+                <path d=""M495.7775 120.1115L494.9857 105.1324L315 105.1324"" fill=""none"" stroke=""#ee6666""></path>
+                <path d=""M500 120A80 80 0 0 1 506.2878 120.2475L500 200Z"" fill=""#5470c6"" stroke=""#fff"" stroke-linejoin=""round""></path>
+                <path d=""M506.2878 120.2475A80 80 0 1 1 485.1759 121.3855L500 200Z"" fill=""#91cc75"" stroke=""#fff"" stroke-linejoin=""round""></path>
+                <path d=""M485.1759 121.3855A80 80 0 0 1 491.5667 120.4457L500 200Z"" fill=""#fac858"" stroke=""#fff"" stroke-linejoin=""round""></path>
+                <path d=""M491.5667 120.4457A80 80 0 0 1 500 120L500 200Z"" fill=""#ee6666"" stroke=""#fff"" stroke-linejoin=""round""></path>
+                <text dominant-baseline=""central"" text-anchor=""end"" style=""font-size:12px;font-family:sans-serif;"" transform=""translate(750 294.8623)"" fill=""black"">Airplane</text>
+                <text dominant-baseline=""central"" text-anchor=""start"" style=""font-size:12px;font-family:sans-serif;"" transform=""translate(250 131.2324)"" fill=""black"">Car</text>
+                <text dominant-baseline=""central"" text-anchor=""start"" style=""font-size:12px;font-family:sans-serif;"" transform=""translate(250 105.1324)"" fill=""black"">Train</text>
+              </g>
+            </svg>";
 
-
-
-            
-
+            try
+            {
+                var component = Document.Parse(new StringReader(svgString), ParseSourceType.DynamicContent);
+                var svg = (Component)component;
+                Assert.IsInstanceOfType(svg, typeof(SVGCanvas));
+            }
+            catch
+            {
+                Assert.Fail("Svg image has not been parsed");
+            }
         }
 
     }


### PR DESCRIPTION
There is an additional try to parse unit value with InvariantCulture