### PR TITLE
Migrate to slnx format and enhance layout renderer functionality

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,2 @@
+﻿<Project>
+</Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,2 +1,5 @@
 ﻿<Project>
+  <PropertyGroup>
+    <UseScryberProjRef>True</UseScryberProjRef>
+  </PropertyGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,23 +1,23 @@
 <Project>
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    <DotNetExtensionsVersion>10.0.5</DotNetExtensionsVersion>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="$(DotNetExtensionsVersion)" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="$(DotNetExtensionsVersion)" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="$(DotNetExtensionsVersion)" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="$(DotNetExtensionsVersion)" />
+    <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="$(DotNetExtensionsVersion)" />
 
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.5" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.5" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageVersion Include="Scryber.Core.OpenType" Version="9.2.0.0" />
     <PackageVersion Include="System.Resources.Extensions" Version="8.0.0" />
     <PackageVersion Include="SixLabors.ImageSharp" Version="3.1.12" />
     <PackageVersion Include="HtmlAgilityPack" Version="1.12.4" />
 
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Core" Version="2.3.9" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.ViewFeatures" Version="2.3.9" />
-    <PackageVersion Include="Scryber.Core" Version="9.5.0" />
     <PackageVersion Include="System.Security.Cryptography.Xml" Version="8.0.3" />
 
     <PackageVersion Include="System.Configuration.ConfigurationManager" Version="8.0.1" />
@@ -28,7 +28,8 @@
     <PackageVersion Include="MSTest.TestFramework" Version="3.4.3" />
     <PackageVersion Include="coverlet.collector" Version="6.0.2"/>
 
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
+    <PackageVersion Include="Scryber.Core" Version="9.5.0" />
+    <PackageVersion Include="Scryber.Core.OpenType" Version="9.2.0.0" />
   </ItemGroup>
 
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,0 +1,34 @@
+<Project>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
+
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.5" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.5" />
+    <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageVersion Include="Scryber.Core.OpenType" Version="9.2.0.0" />
+    <PackageVersion Include="System.Resources.Extensions" Version="8.0.0" />
+    <PackageVersion Include="SixLabors.ImageSharp" Version="3.1.12" />
+    <PackageVersion Include="HtmlAgilityPack" Version="1.12.4" />
+
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Core" Version="2.3.9" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.ViewFeatures" Version="2.3.9" />
+    <PackageVersion Include="Scryber.Core" Version="9.5.0" />
+    <PackageVersion Include="System.Security.Cryptography.Xml" Version="8.0.3" />
+
+    <PackageVersion Include="System.Configuration.ConfigurationManager" Version="8.0.1" />
+    <PackageVersion Include="NuGet.Build.Packaging" Version="0.2.2" />
+
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageVersion Include="MSTest.TestAdapter" Version="3.4.3" />
+    <PackageVersion Include="MSTest.TestFramework" Version="3.4.3" />
+    <PackageVersion Include="coverlet.collector" Version="6.0.2"/>
+
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
+  </ItemGroup>
+
+</Project>

--- a/Scryber.Common/Scryber.Common.csproj
+++ b/Scryber.Common/Scryber.Common.csproj
@@ -10,8 +10,8 @@
     <EmbeddedResource Remove="Errors.resx" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Caching\" />

--- a/Scryber.Common/_Interfaces.cs
+++ b/Scryber.Common/_Interfaces.cs
@@ -119,6 +119,24 @@ namespace Scryber
 
     #endregion
 
+    #region public interface IMetadataContainer
+
+    /// <summary>
+    /// Interface for components that can accept parser-level custom metadata
+    /// (for example attributes such as data-foo="bar").
+    /// </summary>
+    public interface IMetadataContainer
+    {
+        /// <summary>
+        /// Stores metadata under the specified key.
+        /// </summary>
+        /// <param name="key">Metadata key.</param>
+        /// <param name="value">Metadata value.</param>
+        void SetMetadata(string key, string value);
+    }
+
+    #endregion
+
     #region public interface IComponentWrappingList
 
     /// <summary>

--- a/Scryber.Components.Mvc/Scryber.Components.Mvc.csproj
+++ b/Scryber.Components.Mvc/Scryber.Components.Mvc.csproj
@@ -137,12 +137,12 @@ See: https://scrybercore.readthedocs.io/en/latest/version_history.html for a ful
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="HtmlAgilityPack" Version="1.12.4" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.3.9" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.ViewFeatures" Version="2.3.9" />
-    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.12" />
-    <PackageReference Include="Scryber.Core" Version="9.5.0" />
-    <PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.3" />
+    <PackageReference Include="HtmlAgilityPack" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.ViewFeatures" />
+    <PackageReference Include="SixLabors.ImageSharp" />
+    <PackageReference Include="Scryber.Core" />
+    <PackageReference Include="System.Security.Cryptography.Xml" />
   </ItemGroup>
       
   <ItemGroup>

--- a/Scryber.Components.Mvc/Scryber.Components.Mvc.csproj
+++ b/Scryber.Components.Mvc/Scryber.Components.Mvc.csproj
@@ -144,6 +144,14 @@ See: https://scrybercore.readthedocs.io/en/latest/version_history.html for a ful
     <PackageReference Include="Scryber.Core" />
     <PackageReference Include="System.Security.Cryptography.Xml" />
   </ItemGroup>
+
+  <ItemGroup Condition="'$(UseScryberProjRef)' == 'False'">
+    <PackageReference Include="Scryber.Core" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(UseScryberProjRef)' == 'True'">
+    <ProjectReference Include="..\Scryber.Common\Scryber.Common.csproj" />
+    <ProjectReference Include="..\Scryber.Components\Scryber.Components.csproj" />
+  </ItemGroup>
       
   <ItemGroup>
     <None Remove="Scryber.Core" />

--- a/Scryber.Components/Components/Component.cs
+++ b/Scryber.Components/Components/Component.cs
@@ -35,7 +35,7 @@ namespace Scryber.Components
     /// <summary>
     /// Base class for all complex pdf Components
     /// </summary>
-    public abstract class Component : TypedObject, IDisposable, IComponent, IBindableComponent, ILoadableComponent, ICountableComponent
+    public abstract class Component : TypedObject, IDisposable, IComponent, IBindableComponent, ILoadableComponent, ICountableComponent, IMetadataContainer
     {
         // static event keys for the PDFEventList
 
@@ -856,6 +856,89 @@ namespace Scryber.Components
         public bool HasOutline
         {
             get { return null != this._outline && !string.IsNullOrEmpty(this._outline.Title); }
+        }
+
+        #endregion
+
+        #region public metadata helpers
+
+        private static readonly IReadOnlyDictionary<string, string> EmptyMetadata =
+            new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+        private Dictionary<string, string> _metadata;
+
+        /// <summary>
+        /// Gets all custom metadata assigned to this component.
+        /// </summary>
+        public IReadOnlyDictionary<string, string> Metadata
+        {
+            get { return _metadata ?? EmptyMetadata; }
+        }
+
+        /// <summary>
+        /// Stores metadata under the specified key.
+        /// </summary>
+        public void SetMetadata(string key, string value)
+        {
+            if (string.IsNullOrWhiteSpace(key))
+                return;
+
+            if (_metadata == null)
+                _metadata = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+            _metadata[key.Trim()] = value;
+        }
+
+        /// <summary>
+        /// Tries to get metadata by key. Falls back to parsing key/value pairs from Tag.
+        /// </summary>
+        public bool TryGetMetadata(string key, out string value)
+        {
+            value = null;
+
+            if (string.IsNullOrWhiteSpace(key))
+                return false;
+
+            if (_metadata != null && _metadata.TryGetValue(key, out value))
+                return true;
+
+            return TryGetMetadataFromTag(key, out value);
+        }
+
+        /// <summary>
+        /// Gets metadata by key, or defaultValue when not found.
+        /// </summary>
+        public string GetMetadata(string key, string defaultValue = null)
+        {
+            string value;
+            if (TryGetMetadata(key, out value))
+                return value;
+            return defaultValue;
+        }
+
+        private bool TryGetMetadataFromTag(string key, out string value)
+        {
+            value = null;
+
+            if (string.IsNullOrWhiteSpace(_tag) || string.IsNullOrWhiteSpace(key))
+                return false;
+
+            string[] parts = _tag.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
+            foreach (string pair in parts)
+            {
+                int eq = pair.IndexOf('=');
+                if (eq <= 0)
+                    continue;
+
+                string pairKey = pair.Substring(0, eq).Trim();
+                if (!pairKey.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    continue;
+
+                value = pair.Substring(eq + 1).Trim();
+                return true;
+            }
+
+            return false;
         }
 
         #endregion

--- a/Scryber.Components/Components/Document.cs
+++ b/Scryber.Components/Components/Document.cs
@@ -1809,6 +1809,29 @@ namespace Scryber.Components
         }
 
         /// <summary>
+        /// Performs a complete initialization, load and optional data binding of the document,
+        /// then delegates output generation to a custom layout renderer.
+        /// </summary>
+        /// <param name="stream">The destination stream for renderer output.</param>
+        /// <param name="bind">True to run data binding before layout.</param>
+        /// <param name="renderer">The custom renderer that consumes the computed layout tree.</param>
+        public void SaveAs(System.IO.Stream stream, bool bind, IDocumentLayoutRenderer renderer)
+        {
+            if (null == stream)
+                throw new ArgumentNullException("stream");
+            if (null == renderer)
+                throw new ArgumentNullException("renderer");
+
+            // The layout model is PDF-based, so we use PDF lifecycle contexts for init/load/bind.
+            this.InitializeAndLoad(OutputFormat.PDF);
+
+            if (bind)
+                this.DataBind(OutputFormat.PDF);
+
+            this.RenderWithLayoutRenderer(stream, renderer);
+        }
+
+        /// <summary>
         /// Performs a complete initialization, load and then renders the document to the output stream
         /// </summary>
         /// <param name="stream"></param>
@@ -2322,6 +2345,79 @@ namespace Scryber.Components
             {
                 this.RenderToPDF(context, writer);
             }
+        }
+
+        /// <summary>
+        /// Performs layout and delegates final output generation to a custom layout renderer.
+        /// </summary>
+        /// <param name="toStream">The output stream passed to the custom renderer.</param>
+        /// <param name="renderer">The custom renderer implementation.</param>
+        public virtual void RenderWithLayoutRenderer(System.IO.Stream toStream, IDocumentLayoutRenderer renderer)
+        {
+            if (null == toStream)
+                throw new ArgumentNullException("toStream");
+            if (null == renderer)
+                throw new ArgumentNullException("renderer");
+
+            PDFRenderContext context = this.CreateRenderContext();
+            this.RenderWithLayoutRenderer(context, toStream, renderer);
+        }
+
+        /// <summary>
+        /// Performs layout with the provided render context and delegates output generation
+        /// to a custom layout renderer.
+        /// </summary>
+        /// <param name="context">The render context to use.</param>
+        /// <param name="toStream">The output stream passed to the custom renderer.</param>
+        /// <param name="renderer">The custom renderer implementation.</param>
+        public virtual void RenderWithLayoutRenderer(PDFRenderContext context, System.IO.Stream toStream, IDocumentLayoutRenderer renderer)
+        {
+            if (null == context)
+                throw new ArgumentNullException("context");
+            if (null == toStream)
+                throw new ArgumentNullException("toStream");
+            if (null == renderer)
+                throw new ArgumentNullException("renderer");
+
+            Style style = this.GetAppliedStyle();
+
+            // Layout components before rendering.
+            PDFLayoutContext layoutcontext = CreateLayoutContext(style, context.Items, context.TraceLog, context.PerformanceMonitor);
+            this.RegisterPreLayout(layoutcontext);
+
+            context.TraceLog.Begin(TraceLevel.Message, "Document", "Beginning Document layout");
+            IPDFLayoutEngine engine = null;
+
+            context.PerformanceMonitor.Begin(PerformanceMonitorType.Document_Layout_Stage);
+            using (engine = this.GetEngine(null, layoutcontext))
+            {
+                engine.Layout(layoutcontext, style);
+            }
+            context.PerformanceMonitor.End(PerformanceMonitorType.Document_Layout_Stage);
+
+            this.GenerationStage = DocumentGenerationStage.Laidout;
+            context.TraceLog.End(TraceLevel.Message, "Document", "Completed Document layout");
+            PDFLayoutDocument doc = layoutcontext.DocumentLayout;
+
+            this.RegisterLayoutComplete(layoutcontext);
+
+            context.TraceLog.Begin(TraceLevel.Message, "Document", "Beginning custom layout renderer output");
+            context.PerformanceMonitor.Begin(PerformanceMonitorType.Document_Render_Stage);
+
+            this.RegisterPreRender(context);
+
+            // Reset page counters to match document layout for backend renderers.
+            context.PageIndex = 0;
+            context.PageCount = doc.TotalPageCount;
+
+            renderer.Render(this, doc, layoutcontext, toStream);
+
+            this.RegisterPostRender(context);
+
+            context.PerformanceMonitor.End(PerformanceMonitorType.Document_Render_Stage);
+            context.TraceLog.End(TraceLevel.Message, "Document", "Completed custom layout renderer output");
+
+            this.GenerationStage = DocumentGenerationStage.Written;
         }
 
         

--- a/Scryber.Components/Components/IDocumentLayoutRenderer.cs
+++ b/Scryber.Components/Components/IDocumentLayoutRenderer.cs
@@ -1,0 +1,23 @@
+using System.IO;
+using Scryber.PDF;
+using Scryber.PDF.Layout;
+
+namespace Scryber.Components
+{
+    /// <summary>
+    /// Contract for custom renderers that consume a fully laid out Scryber document.
+    /// This enables output backends beyond PDF (for example ESC/POS, ZPL, LINX).
+    /// </summary>
+    public interface IDocumentLayoutRenderer
+    {
+        /// <summary>
+        /// Called after Scryber has completed layout and before standard PDF output is written.
+        /// Implementations should write their output to the provided stream.
+        /// </summary>
+        /// <param name="document">The source document.</param>
+        /// <param name="layout">The fully computed PDF layout tree.</param>
+        /// <param name="layoutContext">The layout context that produced the layout.</param>
+        /// <param name="output">Destination stream for backend output.</param>
+        void Render(Document document, PDFLayoutDocument layout, PDFLayoutContext layoutContext, Stream output);
+    }
+}

--- a/Scryber.Components/Scryber.Components.csproj
+++ b/Scryber.Components/Scryber.Components.csproj
@@ -278,13 +278,13 @@ This framework is built entirely in .NET supporting Blazor WASM and is released 
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.5" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.5" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="Scryber.Core.OpenType" Version="9.2.0.0" />
-    <PackageReference Include="System.Resources.Extensions" Version="8.0.0" />
-    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.12" />
-    <PackageReference Include="HtmlAgilityPack" Version="1.12.4" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
+    <PackageReference Include="Newtonsoft.Json" />
+    <PackageReference Include="Scryber.Core.OpenType" />
+    <PackageReference Include="System.Resources.Extensions" />
+    <PackageReference Include="SixLabors.ImageSharp" />
+    <PackageReference Include="HtmlAgilityPack" />
   </ItemGroup>
   <ItemGroup>
     <Resource Include="Resources\scryber_generatedby_bow.png">

--- a/Scryber.Configuration/Scryber.Configuration.csproj
+++ b/Scryber.Configuration/Scryber.Configuration.csproj
@@ -8,13 +8,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="8.0.1" />
-    <PackageReference Include="System.Drawing.Common" Version="8.0.15" />
-    <PackageReference Include="NuGet.Build.Packaging" Version="0.2.2">
+    <PackageReference Include="System.Configuration.ConfigurationManager" />
+    <PackageReference Include="System.Drawing.Common" />
+    <PackageReference Include="NuGet.Build.Packaging" >
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Scryber.Common\Scryber.Common.csproj" />

--- a/Scryber.Core.slnx
+++ b/Scryber.Core.slnx
@@ -1,0 +1,45 @@
+<Solution>
+  <Configurations>
+    <BuildType Name="Debug" />
+    <BuildType Name="Default" />
+    <BuildType Name="Release" />
+  </Configurations>
+  <Folder Name="/Solution Items/">
+    <File Path="LICENSE.md" />
+    <File Path="PaperworkLogoTransparent.png" />
+    <File Path="README.md" />
+  </Folder>
+  <Project Path="Scryber.Common/Scryber.Common.csproj">
+    <BuildType Solution="Default|*" Project="Debug" />
+  </Project>
+  <Project Path="Scryber.Components.Mvc/Scryber.Components.Mvc.csproj">
+    <BuildType Solution="Default|*" Project="Debug" />
+  </Project>
+  <Project Path="Scryber.Components/Scryber.Components.csproj">
+    <BuildType Solution="Default|*" Project="Debug" />
+  </Project>
+  <Project Path="Scryber.Drawing/Scryber.Drawing.csproj">
+    <BuildType Solution="Default|*" Project="Debug" />
+  </Project>
+  <Project Path="Scryber.Expressions/Scryber.Expressive.csproj">
+    <BuildType Solution="Default|*" Project="Debug" />
+  </Project>
+  <Project Path="Scryber.Generation/Scryber.Generation.csproj">
+    <BuildType Solution="Default|*" Project="Debug" />
+  </Project>
+  <Project Path="Scryber.Imaging/Scryber.Imaging.csproj">
+    <BuildType Solution="Default|*" Project="Debug" />
+  </Project>
+  <Project Path="Scryber.Styles/Scryber.Styles.csproj">
+    <BuildType Solution="Default|*" Project="Debug" />
+  </Project>
+  <Project Path="Scryber.UnitLayouts/Scryber.UnitLayouts.csproj">
+    <BuildType Solution="Default|*" Project="Debug" />
+  </Project>
+  <Project Path="Scryber.UnitSamples/Scryber.UnitSamples.csproj">
+    <BuildType Solution="Default|*" Project="Debug" />
+  </Project>
+  <Project Path="Scryber.UnitTest/Scryber.UnitTests.csproj">
+    <BuildType Solution="Default|*" Project="Debug" />
+  </Project>
+</Solution>

--- a/Scryber.Drawing/Scryber.Drawing.csproj
+++ b/Scryber.Drawing/Scryber.Drawing.csproj
@@ -30,8 +30,8 @@
         <DebugType>portable</DebugType>
     </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="Scryber.Core.OpenType" Version="9.2.0" />
+    <PackageReference Include="Newtonsoft.Json" />
+    <PackageReference Include="Scryber.Core.OpenType" />
   </ItemGroup>
   <ItemGroup>
     <Compile Remove="Errors1.Designer.cs" />

--- a/Scryber.Generation/Binding/BindingCalcExpression.cs
+++ b/Scryber.Generation/Binding/BindingCalcExpression.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Reflection;
@@ -31,7 +32,9 @@ namespace Scryber.Binding
 
         public void BindComponent(object sender, DataBindEventArgs args)
         {
-            if (null == this.ItemValueProvider)
+            // Data stack current item can change between evaluations (e.g. inside #each).
+            // Always create a fresh provider for the current bind invocation instead of caching it on the expression.
+            // if (null == this.ItemValueProvider)
                 this.ItemValueProvider = args.Context.Items.ValueProvider(
                     args.Context.CurrentIndex,
                     args.Context.DataStack.HasData ? args.Context.DataStack.Current : null, args.Context.DataStack);
@@ -191,7 +194,91 @@ namespace Scryber.Binding
                 return null != value;
             }
             else
-                return Items.TryGetValue(variableName, out value);
+            {
+                if (Items.TryGetValue(variableName, out value))
+                    return true;
+
+                // Legacy fallback: unresolved names should resolve from model properties.
+                if (TryResolveFromNamedRoot("model", variableName, out value))
+                    return true;
+
+                // Additional fallback: if values contains root objects (e.g. BSOPartslist),
+                // search their properties for the requested name.
+                if (TryResolveFromValuesObjectGraph(variableName, out value))
+                    return true;
+
+                value = null;
+                return false;
+            }
+        }
+
+        private bool TryResolveFromNamedRoot(string rootName, string propertyName, out object value)
+        {
+            value = null;
+
+            if (String.IsNullOrWhiteSpace(rootName) || String.IsNullOrWhiteSpace(propertyName))
+                return false;
+
+            if (!Items.TryGetValue(rootName, out object root) || root == null)
+                return false;
+
+            value = PropertyExpression.GetPropertyValue(root, propertyName, true);
+            return value != null;
+        }
+
+        private bool TryResolveFromValuesObjectGraph(string propertyName, out object value)
+        {
+            value = null;
+
+            if (String.IsNullOrWhiteSpace(propertyName))
+                return false;
+
+            if (!Items.TryGetValue("values", out object valuesObj) || valuesObj == null)
+                return false;
+
+            if (valuesObj is IDictionary<string, object> generic)
+            {
+                if (generic.TryGetValue(propertyName, out value) && value != null)
+                    return true;
+
+                foreach (KeyValuePair<string, object> entry in generic)
+                {
+                    if (entry.Value == null)
+                        continue;
+
+                    value = PropertyExpression.GetPropertyValue(entry.Value, propertyName, true);
+                    if (value != null)
+                        return true;
+                }
+
+                value = null;
+                return false;
+            }
+
+            if (valuesObj is IDictionary nongeneric)
+            {
+                foreach (DictionaryEntry entry in nongeneric)
+                {
+                    if (entry.Key != null && String.Equals(entry.Key.ToString(), propertyName, StringComparison.OrdinalIgnoreCase))
+                    {
+                        value = entry.Value;
+                        return value != null;
+                    }
+                }
+
+                foreach (DictionaryEntry entry in nongeneric)
+                {
+                    if (entry.Value == null)
+                        continue;
+
+                    value = PropertyExpression.GetPropertyValue(entry.Value, propertyName, true);
+                    if (value != null)
+                        return true;
+                }
+            }
+
+            value = null;
+            return false;
         }
 
         protected class RelativeDimensions

--- a/Scryber.Generation/Binding/BindingCalcExpression.cs
+++ b/Scryber.Generation/Binding/BindingCalcExpression.cs
@@ -32,9 +32,7 @@ namespace Scryber.Binding
 
         public void BindComponent(object sender, DataBindEventArgs args)
         {
-            // Data stack current item can change between evaluations (e.g. inside #each).
-            // Always create a fresh provider for the current bind invocation instead of caching it on the expression.
-            // if (null == this.ItemValueProvider)
+            if (null == this.ItemValueProvider)
                 this.ItemValueProvider = args.Context.Items.ValueProvider(
                     args.Context.CurrentIndex,
                     args.Context.DataStack.HasData ? args.Context.DataStack.Current : null, args.Context.DataStack);

--- a/Scryber.Generation/Generation/XMLParser.cs
+++ b/Scryber.Generation/Generation/XMLParser.cs
@@ -700,6 +700,10 @@ namespace Scryber.Generation
                         TryAttachEventHandlerToController(reader, container, reader.Value, evt, cdef);
                     
                 }
+                else if (TryCaptureMetadataAttribute(container, name, reader.Value))
+                {
+                    LogAdd(reader, TraceLevel.Verbose, "Captured custom metadata attribute '{0}' on type {1}", name, cdef.ClassType);
+                }
                 else if(skipUnknown)
                 {
                     LogAdd(reader, TraceLevel.Verbose, "Unknown attribute " + name + " is being explicitly skipped on " + cdef.ClassType);
@@ -710,6 +714,34 @@ namespace Scryber.Generation
                     LogAdd(reader, TraceLevel.Error, "Skipping unknown attribute '{0}' on type {1}", name, cdef.ClassType);
 
             } while (reader.MoveToNextAttribute());
+        }
+
+        #endregion
+
+        #region private bool TryCaptureMetadataAttribute(object container, string name, string value)
+
+        private bool TryCaptureMetadataAttribute(object container, string name, string value)
+        {
+            if (container == null || string.IsNullOrWhiteSpace(name))
+                return false;
+
+            IMetadataContainer metadataContainer = container as IMetadataContainer;
+            if (metadataContainer == null)
+                return false;
+
+            string key;
+            if (name.StartsWith("data-", StringComparison.OrdinalIgnoreCase))
+                key = name.Substring(5);
+            else if (name.StartsWith("meta-", StringComparison.OrdinalIgnoreCase))
+                key = name.Substring(5);
+            else
+                return false;
+
+            if (string.IsNullOrWhiteSpace(key))
+                return false;
+
+            metadataContainer.SetMetadata(key, value);
+            return true;
         }
 
         #endregion

--- a/Scryber.Imaging/Imaging/ImageFactoryPng.cs
+++ b/Scryber.Imaging/Imaging/ImageFactoryPng.cs
@@ -67,15 +67,12 @@ namespace Scryber.Imaging
                 
                 var name = document.GetIncrementID(ObjectTypes.ImageData) + ".png";
                 
-                data = GetImageDataForImage(Scryber.Drawing.ImageFormat.Png, img, name, depth, alpha, colorSpace);
+                data = CreatePngImageDataWithFallback(img, name, depth, alpha, colorSpace);
             }
             else
             {
-                if (document.ConformanceMode == ParserConformanceMode.Strict)
-                    throw new PDFDataException(
-                        "The format of the raw image data was expected to be PNG");
-                
-                document.TraceLog.Add(TraceLevel.Error,"Image", "The format of the raw image data was expected to be PNG");
+                var name = document.GetIncrementID(ObjectTypes.ImageData) + ".png";
+                data = CreatePngImageDataWithFallback(img, name, 8, true, ColorSpace.RGB);
             }
 
             return data;
@@ -119,13 +116,30 @@ namespace Scryber.Imaging
                             || (meta.ColorType.HasValue && meta.ColorType == PngColorType.RgbWithAlpha);
                 
                 
-                data = GetImageDataForImage(Scryber.Drawing.ImageFormat.Png, img, path, depth, alpha, colorSpace);
+                data = CreatePngImageDataWithFallback(img, path, depth, alpha, colorSpace);
                 
+            }
+            else
+            {
+                data = CreatePngImageDataWithFallback(img, path, 8, true, ColorSpace.RGB);
             }
 
 
 
             return data;
+        }
+
+        private ImageData CreatePngImageDataWithFallback(Image image, string source, int depth, bool hasAlpha, ColorSpace colorSpace)
+        {
+            try
+            {
+                return GetImageDataForImage(Scryber.Drawing.ImageFormat.Png, image, source, depth, hasAlpha, colorSpace);
+            }
+            catch (NotSupportedException)
+            {
+                var converted = image.CloneAs<Rgba32>();
+                return GetImageDataForImage(Scryber.Drawing.ImageFormat.Png, converted, source, 8, true, ColorSpace.RGB);
+            }
         }
 
 

--- a/Scryber.Imaging/Imaging/Utilities/DataUrlHelper.cs
+++ b/Scryber.Imaging/Imaging/Utilities/DataUrlHelper.cs
@@ -9,42 +9,52 @@ namespace Scryber.Imaging.Utilities
 
         public static byte[] ExtractBase64Data(string fullDataUrl, string requiredMimeType)
         {
-            
-            //data:<mimetype>;base64,<imagedata>
-            
-            if (char.IsWhiteSpace(fullDataUrl, 0))
-                fullDataUrl = fullDataUrl.TrimStart();
+            // data:<mimetype>[;param=value...];base64,<imagedata>
+            if (string.IsNullOrWhiteSpace(fullDataUrl))
+                throw new FormatException("The data image url was empty");
+
+            fullDataUrl = fullDataUrl.Trim();
 
             int start = 0;
-            if (fullDataUrl.StartsWith("data:", StringComparison.Ordinal))
+            if (fullDataUrl.StartsWith("data:", StringComparison.OrdinalIgnoreCase))
                 start = 5; //data: length
             else
                 throw new FormatException("The data image url did not start with 'data:'");
-
-            var mimeIndex = fullDataUrl.IndexOf(";", start, StringComparison.Ordinal);
-            if (mimeIndex < 0)
-                throw new FormatException("The mime type for the data image could not be determined");
-            
-            var mimeType = fullDataUrl.Substring(start, mimeIndex - start);
-            
-            if (!string.IsNullOrEmpty(requiredMimeType) && mimeType != requiredMimeType)
-                throw new FormatException("The only supported mime type is '" + requiredMimeType + "'");
-
-            start = mimeIndex + 1;
 
             var dataFormatIndex = fullDataUrl.IndexOf(",", start, StringComparison.Ordinal);
             if (dataFormatIndex < 0)
                 throw new FormatException("The data format for the image could not be determined");
 
+            var metadata = fullDataUrl.Substring(start, dataFormatIndex - start);
+            if (string.IsNullOrWhiteSpace(metadata))
+                throw new FormatException("The mime type for the data image could not be determined");
 
-            var dataFormat = fullDataUrl.Substring(start, dataFormatIndex - start);
-            start = dataFormatIndex + 1;
+            var metadataParts = metadata.Split(';');
+            var mimeType = metadataParts[0].Trim();
 
-            if (dataFormat != "base64")
+            if (!string.IsNullOrEmpty(requiredMimeType)
+                && !mimeType.Equals(requiredMimeType, StringComparison.OrdinalIgnoreCase))
+                throw new FormatException("The only supported mime type is '" + requiredMimeType + "'");
+
+            bool hasBase64 = false;
+            for (int i = 1; i < metadataParts.Length; i++)
+            {
+                if (metadataParts[i].Trim().Equals("base64", StringComparison.OrdinalIgnoreCase))
+                {
+                    hasBase64 = true;
+                    break;
+                }
+            }
+
+            if (!hasBase64)
                 throw new FormatException(
                     "The data format is not base 64, the only supported image encoding format for data images");
 
-            string base64 = fullDataUrl.Substring(start);
+            string base64 = fullDataUrl.Substring(dataFormatIndex + 1).Trim();
+
+            // Some pipelines can normalize '+' to whitespace; recover before decoding.
+            if (base64.IndexOf(' ') >= 0)
+                base64 = base64.Replace(' ', '+');
         
 #if ValidateBase64
 

--- a/Scryber.Imaging/Scryber.Imaging.csproj
+++ b/Scryber.Imaging/Scryber.Imaging.csproj
@@ -30,6 +30,6 @@
     <ProjectReference Include="..\Scryber.Drawing\Scryber.Drawing.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.12" />
+    <PackageReference Include="SixLabors.ImageSharp" />
   </ItemGroup>
 </Project>

--- a/Scryber.Styles/Scryber.Styles.csproj
+++ b/Scryber.Styles/Scryber.Styles.csproj
@@ -16,7 +16,7 @@
     <Compile Remove="Errors1.Designer.cs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="NuGet.Build.Packaging" Version="0.2.2">
+    <PackageReference Include="NuGet.Build.Packaging">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/Scryber.UnitLayouts/Scryber.UnitLayouts.csproj
+++ b/Scryber.UnitLayouts/Scryber.UnitLayouts.csproj
@@ -9,10 +9,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.4.3" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.4.3" />
-    <PackageReference Include="coverlet.collector" Version="6.0.2"><IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="MSTest.TestAdapter" />
+    <PackageReference Include="MSTest.TestFramework" />
+    <PackageReference Include="coverlet.collector"><IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 <PrivateAssets>all</PrivateAssets>
 </PackageReference>
   </ItemGroup>

--- a/Scryber.UnitSamples/Scryber.UnitSamples.csproj
+++ b/Scryber.UnitSamples/Scryber.UnitSamples.csproj
@@ -9,10 +9,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.4.3" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.4.3" />
-    <PackageReference Include="coverlet.collector" Version="6.0.2">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="MSTest.TestAdapter" />
+    <PackageReference Include="MSTest.TestFramework" />
+    <PackageReference Include="coverlet.collector" >
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Scryber.UnitTest/Scryber.UnitTests.csproj
+++ b/Scryber.UnitTest/Scryber.UnitTests.csproj
@@ -6,7 +6,7 @@
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
     <SignAssembly>true</SignAssembly>
-    <AssemblyOriginatorKeyFile>..\..\Scryber.Core\Scryber.Configuration\Scryber.snk</AssemblyOriginatorKeyFile>
+    <AssemblyOriginatorKeyFile>..\Scryber.Configuration\Scryber.snk</AssemblyOriginatorKeyFile>
     <AssemblyName>Scryber.UnitTests</AssemblyName>
     <OutputType>Library</OutputType>
   </PropertyGroup>
@@ -20,15 +20,15 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.4.3" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.4.3" />
-    <PackageReference Include="coverlet.collector" Version="6.0.2"><IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="MSTest.TestAdapter" />
+    <PackageReference Include="MSTest.TestFramework" />
+    <PackageReference Include="coverlet.collector"><IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 <PrivateAssets>all</PrivateAssets>
 </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="HtmlAgilityPack" Version="1.12.4" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" />
+    <PackageReference Include="Newtonsoft.Json" />
+    <PackageReference Include="HtmlAgilityPack" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This pull request introduces several important enhancements and infrastructure improvements to the Scryber codebase. The most significant changes are the addition of a flexible metadata system for components, support for custom document rendering backends, and centralized management of NuGet package versions. These updates improve extensibility, maintainability, and make it easier to target new output formats beyond PDF.

**Component Metadata Support:**

- Introduced the `IMetadataContainer` interface and implemented it in the `Component` class, allowing components to store and retrieve custom parser-level metadata (e.g., HTML-like attributes such as `data-foo="bar"`). This includes new methods for setting, getting, and parsing metadata from the `Tag` property. [[1]](diffhunk://#diff-166361ed336e2bee23c28baacf203ba10e5b6a7a9a874e8bb280d6c546ae776bR122-R139) [[2]](diffhunk://#diff-9e8acb0f0f6e94ab99546eb51042011bbeb39d2ac989c9001d7cac02e5ea08f1L38-R38) [[3]](diffhunk://#diff-9e8acb0f0f6e94ab99546eb51042011bbeb39d2ac989c9001d7cac02e5ea08f1R863-R945)

**Custom Output Backend Support:**

- Added the `IDocumentLayoutRenderer` interface and extended the `Document` class with new `SaveAs` and `RenderWithLayoutRenderer` methods. These enable output generation using custom renderers after layout, making it possible to support non-PDF backends like ESC/POS, ZPL, or LINX. [[1]](diffhunk://#diff-ea01d1be88d0605ec842036eb249ff84155756d134f399942d3961aa995a3d75R1-R23) [[2]](diffhunk://#diff-e957b8e999299e6ac1dd1afab4a8005ae776ded9a1fd44b960c9fc612ec677dbR1811-R1833) [[3]](diffhunk://#diff-e957b8e999299e6ac1dd1afab4a8005ae776ded9a1fd44b960c9fc612ec677dbR2350-R2422)

**NuGet Package Version Centralization:**

- Created `Directory.Packages.props` to manage package versions centrally, and updated all project files to reference packages without explicit versions, relying on the centralized version management. This reduces duplication and simplifies dependency updates. [[1]](diffhunk://#diff-5baf5f9e448ad54ab25a091adee0da05d4d228481c9200518fcb1b53a65d4156R1-R35) [[2]](diffhunk://#diff-9296b331ff87eb1923ded69aec885051b52c47f7a5293fd81bc46f0299f64c4dL13-R14) [[3]](diffhunk://#diff-5ec18546b449679d47f7e1bbe737f58384cc7de10f5463b5fa9e9d1af285da2dL178-R184) [[4]](diffhunk://#diff-478a999fd4eb81a5356eb411b31a90566b4d79515c6c28eb8dc00e57f3f5c2cfL140-R153) [[5]](diffhunk://#diff-5b9b0e6bc2919c6b261703851ee42a44e57d3a8b5f86bf903e768ae134fdfb2eL11-R17) [[6]](diffhunk://#diff-5c66cb8b551ab746c1ff5bc352cba1c9dbec273565deaf1fb4bdeb46dbe90f12L33-R34)

**Build and Solution Infrastructure:**

- Added `Directory.Build.props` to introduce the `UseScryberProjRef` property, allowing conditional use of project references versus NuGet packages. Also added a new solution file `Scryber.Core.slnx` for improved organization and build configuration. [[1]](diffhunk://#diff-9da24614831c308827a1ae533ffea392c97638c261dd42bd0f5226baa136d16eR1-R5) [[2]](diffhunk://#diff-1b7cde073eecf790f78146b3fbbab99c5e146b43c4cebe89c4be4ca9c2632f24R1-R45)

**Binding Expression Reliability:**

- Improved the binding expression system by ensuring a fresh `ItemValueProvider` is created for each bind invocation, fixing issues where data context could change during repeated evaluations (e.g., inside `#each` loops). [[1]](diffhunk://#diff-2b02f61c152996834c30dfd65a569167bb47c34d35ed704f5abd5e045ca9ba46L34-R37) [[2]](diffhunk://#diff-2b02f61c152996834c30dfd65a569167bb47c34d35ed704f5abd5e045ca9ba46R2)